### PR TITLE
Fix component name typo

### DIFF
--- a/otherComponents.tsx
+++ b/otherComponents.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import Image from 'next/image'
 
-function otherComponents() {
+function OtherComponents() {
     return (
         <>
             <div className="relative isolate overflow-hidden bg-gradient-to-b from-hvblue-100/20 pt-14">
@@ -51,4 +51,4 @@ function otherComponents() {
     )
 }
 
-export default otherComponents
+export default OtherComponents


### PR DESCRIPTION
## Summary
- rename `otherComponents` component to `OtherComponents`

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68439cdb37f483209a0397777a3b82a4